### PR TITLE
feat(launch): report mod loader installer progress and complete Java runtime at launch

### DIFF
--- a/crates/download/src/lib.rs
+++ b/crates/download/src/lib.rs
@@ -366,7 +366,10 @@ pub fn filter_existing_and_verified_files(
         completed.fetch_add(1, Ordering::SeqCst);
         match check_result {
             Some(x) => !x,
-            None => true,
+            // Without an expected checksum the content cannot be verified,
+            // so an existing file counts as complete instead of being
+            // redownloaded on every run.
+            None => false,
         }
     };
     let downloads: Vec<_> = downloads.into_par_iter().filter(filter_op).collect();

--- a/crates/install/index.ts
+++ b/crates/install/index.ts
@@ -168,20 +168,38 @@ export enum Job {
     InstallModLoader = "InstallModLoader",
 }
 
+export type ModLoaderProgress =
+    | {
+          phase: "prepare"
+      }
+    | {
+          phase: "downloadInstaller"
+          detail?: DownloadState
+      }
+    | {
+          phase: "prefetchDependencies"
+          detail?: DownloadState
+      }
+    | {
+          phase: "runInstaller"
+          detail?: { message: string }
+      }
+
 export type InstallProgress =
     | {
           job: Job.Prepare
       }
     | {
           job: Job.InstallGame
-          downloadState?: DownloadState
+          progress?: DownloadState
       }
     | {
           job: Job.InstallJava
-          downloadState?: DownloadState
+          progress?: DownloadState
       }
     | {
           job: Job.InstallModLoader
+          progress?: ModLoaderProgress
       }
 
 export class InstallTask {

--- a/crates/install/src/forge.rs
+++ b/crates/install/src/forge.rs
@@ -17,9 +17,8 @@ use std::{
 };
 
 use config::download::DownloadConfig;
-use download::{download_concurrent, progress::DownloadState};
+use download::{DownloadTask, DownloadTaskType, download_concurrent, progress::DownloadState};
 use folder::{DATA_LOCATION, MinecraftLocation};
-use futures::AsyncWriteExt;
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use shared::HTTP_CLIENT;
@@ -28,7 +27,9 @@ use platform::DELIMITER;
 use version::{Version, resolve_libraries};
 use zip::ZipArchive;
 
-use crate::{error::*, vanilla::generate_libraries_downloads};
+use crate::{
+    ModLoaderProgress, ModLoaderReporter, error::*, vanilla::generate_libraries_downloads,
+};
 
 /// A list of Forge versions for a given Minecraft version.
 #[derive(Clone, Deserialize, Serialize)]
@@ -124,6 +125,7 @@ const FORGE_INSTALL_BOOTSTRAPPER_CONIC: &[u8] =
 /// * `forge_version` - The Forge version string to install (e.g., "1.20.1-47.1.0").
 /// * `mcversion` - The Minecraft version string associated with this Forge version.
 /// * `java_path` - The Java executable used to run the installer.
+/// * `reporter` - Progress reporter forwarded to the frontend.
 ///
 /// # Errors
 ///
@@ -137,12 +139,18 @@ pub async fn install(
     forge_version: &str,
     mcversion: &str,
     java_path: &Path,
+    reporter: &ModLoaderReporter,
 ) -> Result<()> {
     info!("Start downloading the forge installer");
-    let installer_path = download_installer(mcversion, forge_version).await?;
-    let _ = prefetch_installer_dependencies(minecraft_location, &installer_path).await;
-    let bangbang93_bootstrapper_installation_result =
-        try_bangbang93_bootstrapper(&minecraft_location.root, &installer_path, java_path).await;
+    let installer_path = download_installer(mcversion, forge_version, reporter).await?;
+    let _ = prefetch_installer_dependencies(minecraft_location, &installer_path, reporter).await;
+    let bangbang93_bootstrapper_installation_result = try_bangbang93_bootstrapper(
+        &minecraft_location.root,
+        &installer_path,
+        java_path,
+        reporter,
+    )
+    .await;
     // The legacy bootstrapper renames the installed version to this id, so it
     // must stay in sync with `Instance::get_version_id` (crates/instance).
     let version_id = format!("{mcversion}-forge-{forge_version}");
@@ -154,6 +162,7 @@ pub async fn install(
                     &installer_path,
                     java_path,
                     &version_id,
+                    reporter,
                 )
                 .await,
             )
@@ -175,6 +184,7 @@ pub async fn install(
 ///
 /// * `mcversion` - The Minecraft version string.
 /// * `forge_version` - The Forge version string.
+/// * `reporter` - Progress reporter forwarded to the frontend.
 ///
 /// # Returns
 ///
@@ -183,7 +193,11 @@ pub async fn install(
 /// # Errors
 ///
 /// Returns an error if the download fails or the file cannot be written.
-pub async fn download_installer(mcversion: &str, forge_version: &str) -> Result<PathBuf> {
+pub async fn download_installer(
+    mcversion: &str,
+    forge_version: &str,
+    reporter: &ModLoaderReporter,
+) -> Result<PathBuf> {
     let installer_url = format!(
         "https://maven.minecraftforge.net/net/minecraftforge/forge/{mcversion}-{forge_version}/forge-{mcversion}-{forge_version}-installer.jar"
     );
@@ -194,15 +208,21 @@ pub async fn download_installer(mcversion: &str, forge_version: &str) -> Result<
     if let Some(parent) = installer_path.parent() {
         async_fs::create_dir_all(parent).await?;
     }
-    let mut file = async_fs::File::create(&installer_path).await?;
-    // TODO: This can also return progress to frontend
-    let response = HTTP_CLIENT
-        .get(installer_url)
-        .send()
-        .await?
-        .error_for_status()?;
-    let src = response.bytes().await?;
-    file.write_all(&src).await?;
+    let checksum = crate::fetch_maven_sha1(&installer_url).await;
+    let progress = DownloadState::default();
+    reporter.report(ModLoaderProgress::DownloadInstaller(progress.clone()));
+    download_concurrent(
+        vec![DownloadTask {
+            url: installer_url,
+            file: installer_path.clone(),
+            checksum,
+            size_bytes: None,
+            task_type: DownloadTaskType::Unknown,
+        }],
+        &progress,
+        DownloadConfig::default(),
+    )
+    .await?;
     info!("Downloaded forge installer");
     Ok(installer_path)
 }
@@ -210,6 +230,7 @@ pub async fn download_installer(mcversion: &str, forge_version: &str) -> Result<
 async fn prefetch_installer_dependencies(
     minecraft_location: &MinecraftLocation,
     installer_path: &Path,
+    reporter: &ModLoaderReporter,
 ) -> Result<()> {
     let file = std::fs::File::open(installer_path)?;
     let mut archive = ZipArchive::new(file)?;
@@ -218,12 +239,9 @@ async fn prefetch_installer_dependencies(
     if let Some(libraries) = version.libraries {
         let libraries = resolve_libraries(libraries)?;
         let download_entries = generate_libraries_downloads(minecraft_location, &libraries);
-        download_concurrent(
-            download_entries,
-            &DownloadState::default(), // TODO: return progress to frontend
-            DownloadConfig::default(),
-        )
-        .await?;
+        let progress = DownloadState::default();
+        reporter.report(ModLoaderProgress::PrefetchDependencies(progress.clone()));
+        download_concurrent(download_entries, &progress, DownloadConfig::default()).await?;
     }
     Ok(())
 }
@@ -232,6 +250,7 @@ async fn try_bangbang93_bootstrapper(
     install_dir: &Path,
     installer_path: &Path,
     java_path: &Path,
+    reporter: &ModLoaderReporter,
 ) -> Result<()> {
     info!("Trying Bangbang93 forge install bootstrapper");
     let bangbang93_bootstrapper_path =
@@ -246,7 +265,7 @@ async fn try_bangbang93_bootstrapper(
         .arg(install_dir)
         .stdout(Stdio::piped())
         .spawn()?;
-    let result = wait_child(child);
+    let result = wait_child(child, reporter);
     async_fs::remove_file(bangbang93_bootstrapper_path).await?;
     result
 }
@@ -261,6 +280,7 @@ async fn try_conicmc_bootstrapper(
     installer_path: &Path,
     java_path: &Path,
     version_id: &str,
+    reporter: &ModLoaderReporter,
 ) -> Result<()> {
     info!("Trying ConicMC forge install bootstrapper");
     let conicmc_bootstrapper_path = save_bootstrapper(FORGE_INSTALL_BOOTSTRAPPER_CONIC).await?;
@@ -275,12 +295,12 @@ async fn try_conicmc_bootstrapper(
         .arg(version_id)
         .stdout(Stdio::piped())
         .spawn()?;
-    let result = wait_child(child);
+    let result = wait_child(child, reporter);
     async_fs::remove_file(conicmc_bootstrapper_path).await?;
     result
 }
 
-fn wait_child(mut child: Child) -> Result<()> {
+fn wait_child(mut child: Child, reporter: &ModLoaderReporter) -> Result<()> {
     let out = child.stdout.take().ok_or(Error::ForgeInstallerFailed)?;
     let mut out = std::io::BufReader::new(out);
     let mut buf = String::new();
@@ -298,6 +318,7 @@ fn wait_child(mut child: Child) -> Result<()> {
             info!("Successfully ran the forge installer");
         } else {
             debug!("[{pid}] {line}");
+            reporter.report_installer_line(line);
         }
     }
     let output = child.wait_with_output()?;

--- a/crates/install/src/lib.rs
+++ b/crates/install/src/lib.rs
@@ -26,10 +26,11 @@ use tauri::{
 use vanilla::generate_download_info;
 
 use config::{Config, get_system_language};
-use download::download_concurrent;
 use download::progress::DownloadState;
+use download::{Checksum, download_concurrent};
 use folder::{DATA_LOCATION, MinecraftLocation};
 use instance::{Instance, InstanceRuntime, ModLoaderType};
+use shared::HTTP_CLIENT;
 use version::{Version, resolve_version};
 
 use crate::{
@@ -163,12 +164,75 @@ async fn cmd_get_neoforge_version_list(state: State<'_, PluginState>) -> Result<
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(tag = "job", content = "downloadState")]
+#[serde(tag = "job", content = "progress")]
 pub enum InstallEvent {
     Prepare,
     InstallGame(DownloadState),
     InstallJava(DownloadState),
-    InstallModLoader,
+    InstallModLoader(ModLoaderProgress),
+}
+
+/// Fine-grained progress of a mod loader installation.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "phase", content = "detail", rename_all = "camelCase")]
+pub enum ModLoaderProgress {
+    /// Preparing the installation (resolving versions and Java).
+    Prepare,
+    /// Downloading the loader installer JAR.
+    DownloadInstaller(DownloadState),
+    /// Prefetching libraries bundled inside the installer JAR (Forge).
+    PrefetchDependencies(DownloadState),
+    /// Running the installer subprocess, carrying its latest log line.
+    RunInstaller { message: String },
+}
+
+/// Clonable handle through which loader installers report [`ModLoaderProgress`].
+#[derive(Clone)]
+pub struct ModLoaderReporter {
+    status: Arc<Mutex<InstallEvent>>,
+}
+
+impl ModLoaderReporter {
+    pub(crate) fn new(status: &Arc<Mutex<InstallEvent>>) -> Self {
+        Self {
+            status: Arc::clone(status),
+        }
+    }
+
+    pub fn report(&self, progress: ModLoaderProgress) {
+        let mut current = self.status.lock().expect("Internal error");
+        *current = InstallEvent::InstallModLoader(progress);
+    }
+
+    /// Reports one output line of the installer subprocess as
+    /// [`ModLoaderProgress::RunInstaller`]. Empty lines are skipped and overly
+    /// long lines are clamped to keep the IPC payload small.
+    pub fn report_installer_line(&self, line: &str) {
+        let line = line.trim();
+        if line.is_empty() {
+            return;
+        }
+        self.report(ModLoaderProgress::RunInstaller {
+            message: line.chars().take(200).collect(),
+        });
+    }
+}
+
+/// Fetches the standard Maven `.sha1` checksum for the artifact behind `url`,
+/// falling back to no checksum when it is unavailable.
+pub(crate) async fn fetch_maven_sha1(url: &str) -> Checksum {
+    let response = match HTTP_CLIENT.get(format!("{url}.sha1")).send().await {
+        Ok(response) => response,
+        Err(_) => return Checksum::None,
+    };
+    let response = match response.error_for_status() {
+        Ok(response) => response,
+        Err(_) => return Checksum::None,
+    };
+    match response.text().await {
+        Ok(text) => Checksum::Sha1(text.trim().to_string()),
+        Err(_) => Checksum::None,
+    }
 }
 
 #[command]
@@ -282,7 +346,7 @@ pub async fn install(
         *status = InstallEvent::InstallJava(progress.clone())
     }
 
-    if instance.config.launch_config.java_path.is_none() {
+    if instance.config.launch_config.java_path.is_none() && config.prefer_mojang_java {
         java::install_for_instance(&instance, &progress, config.download.clone()).await?;
     }
 
@@ -290,11 +354,11 @@ pub async fn install(
         info!("Install mod loader");
         {
             let mut status = status.lock().expect("Internal error");
-            *status = InstallEvent::InstallModLoader;
+            *status = InstallEvent::InstallModLoader(ModLoaderProgress::Prepare);
         }
-        // TODO: mod loader installation progress
+        let reporter = ModLoaderReporter::new(&status);
         let installer_java = resolve_installer_java(&config, &instance).await?;
-        install_mod_loader(runtime, installer_java.path.as_path()).await?;
+        install_mod_loader(runtime, installer_java.path.as_path(), &reporter).await?;
     };
 
     configure_first_launch_language(config, &instance).await;
@@ -352,12 +416,17 @@ async fn resolve_installer_java(
 /// * `runtime` - Instance runtime configuration containing loader type/version.
 /// * `java_path` - The Java executable used to run Java-based installers
 ///   (Forge and NeoForge).
+/// * `reporter` - Progress reporter forwarded to the loader installation.
 ///
 /// # Errors
 /// Returns an error if:
 /// - The loader type/version is missing or malformed.
 /// - The underlying installation function fails.
-pub async fn install_mod_loader(runtime: &InstanceRuntime, java_path: &Path) -> Result<()> {
+pub async fn install_mod_loader(
+    runtime: &InstanceRuntime,
+    java_path: &Path,
+    reporter: &ModLoaderReporter,
+) -> Result<()> {
     let mod_loader_type = runtime
         .mod_loader_type
         .as_ref()
@@ -389,11 +458,12 @@ pub async fn install_mod_loader(runtime: &InstanceRuntime, java_path: &Path) -> 
                 mod_loader_version,
                 &runtime.minecraft,
                 java_path,
+                reporter,
             )
             .await?
         }
         ModLoaderType::Neoforge => {
-            neoforge::install(&DATA_LOCATION.root, mod_loader_version, java_path).await?
+            neoforge::install(&DATA_LOCATION.root, mod_loader_version, java_path, reporter).await?
         }
     }
 

--- a/crates/install/src/neoforge.rs
+++ b/crates/install/src/neoforge.rs
@@ -4,13 +4,14 @@
 
 use std::{io::BufRead, path::Path, path::PathBuf, process::Stdio};
 
+use config::download::DownloadConfig;
+use download::{DownloadTask, DownloadTaskType, download_concurrent, progress::DownloadState};
 use folder::DATA_LOCATION;
-use futures::AsyncWriteExt;
 use log::{debug, error, info};
 use serde_json::Value;
 use shared::HTTP_CLIENT;
 
-use crate::error::*;
+use crate::{ModLoaderProgress, ModLoaderReporter, error::*};
 
 pub async fn get_neoforge_version_list() -> Result<Vec<String>> {
     let legacy_versions = HTTP_CLIENT
@@ -42,6 +43,7 @@ pub async fn get_neoforge_version_list() -> Result<Vec<String>> {
 /// * `install_dir` - The target directory where the client will be installed.
 /// * `neoforge_version` - The version of Neoforge to install.
 /// * `java_path` - The Java executable used to run the installer.
+/// * `reporter` - Progress reporter forwarded to the frontend.
 ///
 /// # Returns
 /// * `Ok(())` on successful installation.
@@ -50,9 +52,10 @@ pub async fn install(
     install_dir: &PathBuf,
     neoforge_version: &str,
     java_path: &Path,
+    reporter: &ModLoaderReporter,
 ) -> Result<()> {
     info!("Start downloading the neoforge installer");
-    let installer_path = download_installer(neoforge_version).await?;
+    let installer_path = download_installer(neoforge_version, reporter).await?;
     info!("Running installer with {}", java_path.display());
 
     let mut command = std::process::Command::new(java_path)
@@ -84,6 +87,7 @@ pub async fn install(
             info!("Successfully ran the neoforge installer");
         } else {
             debug!("[{pid}] {line}");
+            reporter.report_installer_line(line);
         }
     }
 
@@ -99,12 +103,18 @@ pub async fn install(
 /// Downloads the Neoforge installer JAR for the given version.
 ///
 /// # Arguments
+///
 /// * `neoforge_version` - The version to download.
+/// * `reporter` - Progress reporter forwarded to the frontend.
 ///
 /// # Returns
+///
 /// * `Ok(PathBuf)` containing the path to the downloaded installer.
 /// * `Err(Error)` if downloading fails.
-pub async fn download_installer(neoforge_version: &str) -> Result<PathBuf> {
+pub async fn download_installer(
+    neoforge_version: &str,
+    reporter: &ModLoaderReporter,
+) -> Result<PathBuf> {
     let installer_url = format!(
         "https://maven.neoforged.net/releases/net/neoforged/neoforge/{neoforge_version}/neoforge-{neoforge_version}-installer.jar"
     );
@@ -117,13 +127,20 @@ pub async fn download_installer(neoforge_version: &str) -> Result<PathBuf> {
         async_fs::create_dir_all(parent).await?;
     }
 
-    let mut file = async_fs::File::create(&installer_path).await?;
-    let response = HTTP_CLIENT
-        .get(installer_url)
-        .send()
-        .await?
-        .error_for_status()?;
-    let src = response.bytes().await?;
-    file.write_all(&src).await?;
+    let checksum = crate::fetch_maven_sha1(&installer_url).await;
+    let progress = DownloadState::default();
+    reporter.report(ModLoaderProgress::DownloadInstaller(progress.clone()));
+    download_concurrent(
+        vec![DownloadTask {
+            url: installer_url,
+            file: installer_path.clone(),
+            checksum,
+            size_bytes: None,
+            task_type: DownloadTaskType::Unknown,
+        }],
+        &progress,
+        DownloadConfig::default(),
+    )
+    .await?;
     Ok(installer_path)
 }

--- a/crates/launch/index.ts
+++ b/crates/launch/index.ts
@@ -12,9 +12,6 @@ type LaunchProgress =
           job: "Prepare"
       }
     | {
-          job: "RefreshAccount"
-      }
-    | {
           job: "CompleteFiles"
           downloadState?: DownloadState
       }

--- a/crates/launch/src/complete.rs
+++ b/crates/launch/src/complete.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
-    path::PathBuf,
+    path::Path,
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use config::download::DownloadConfig;
-use log::info;
+use log::{info, warn};
 
 use download::progress::DownloadState;
 use folder::{DATA_LOCATION, MinecraftLocation};
@@ -19,20 +19,24 @@ use version::{Version, resolve_version};
 
 use crate::error::*;
 
-/// Completes and verifies all assets and libraries files for the given instance and Minecraft location.
+/// Completes and verifies all assets, libraries and Mojang-provided Java
+/// runtime files for the given instance and Minecraft location.
 ///
 /// This function checks if lock files exist to skip redundant verification. If lock files are missing,
-/// it will verify and download missing or corrupted assets and libraries, then create the lock files.
+/// it will verify and download missing or corrupted assets, libraries and the
+/// Mojang-provided Java runtime (when preferred), then create the lock files.
 /// > NOTE: If game crashed, the lock file should be delete!
 ///
 /// # Arguments
 ///
 /// * `instance` - The Minecraft instance whose files to verify.
 /// * `minecraft_location` - The Minecraft location to resolve file paths.
+/// * `prefer_mojang_java` - Whether the Mojang-provided Java runtime is used.
 pub async fn complete_files(
     instance: &Instance,
     minecraft_location: &MinecraftLocation,
     progress: DownloadState,
+    prefer_mojang_java: bool,
     config: &DownloadConfig,
 ) -> Result<()> {
     let assets_lock_file = DATA_LOCATION
@@ -41,7 +45,7 @@ pub async fn complete_files(
     let libraries_lock_file = DATA_LOCATION
         .get_instance_root(&instance.id)
         .join(".conic-libraries-ok");
-    if try_load_lock_file(&assets_lock_file).await.is_some() {
+    if try_load_lock_file(&assets_lock_file).is_some() {
         info!("Found file \".conic-assets-ok\", no need to check assets files.");
     } else {
         info!("Checking and completing assets files");
@@ -53,41 +57,31 @@ pub async fn complete_files(
         )
         .await?;
         info!("Saving assets lock file");
-        let _ = save_lock_file(&assets_lock_file).await;
+        let _ = save_lock_file(&assets_lock_file);
     }
-    if try_load_lock_file(&libraries_lock_file).await.is_some() {
+    if try_load_lock_file(&libraries_lock_file).is_some() {
         info!("Found file \".conic-libraries-ok\", no need to check libraries files.");
     } else {
         info!("Checking and completing libraries files");
-        complete_libraries_files(instance, minecraft_location, progress, config.clone()).await?;
+        complete_libraries_files(
+            instance,
+            minecraft_location,
+            progress.clone(),
+            config.clone(),
+        )
+        .await?;
         info!("Saving libraries lock file");
-        let _ = save_lock_file(&libraries_lock_file).await;
+        let _ = save_lock_file(&libraries_lock_file);
     }
-    Ok(())
-}
-
-async fn try_load_lock_file(path: &PathBuf) -> Option<()> {
-    let contents = async_fs::read_to_string(path)
-        .await
-        .ok()?
-        .parse::<u64>()
-        .ok()?;
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Incorrect system time")
-        .as_secs();
-    if now - contents > 10 * 24 * 60 * 60 {
-        return None;
-    };
-    Some(())
-}
-
-async fn save_lock_file(path: &PathBuf) -> Result<()> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Incorrect system time")
-        .as_secs();
-    std::fs::write(path, now.to_string())?;
+    // Best-effort: a failure here must not abort the launch because the Java
+    // resolution step either falls back to a system runtime or reports
+    // `NoSuitableJavaRuntime` when nothing usable is available.
+    if prefer_mojang_java
+        && instance.config.launch_config.java_path.is_none()
+        && let Err(error) = complete_java_runtime_files(instance, &progress, config.clone()).await
+    {
+        warn!("Failed to ensure the Mojang-provided Java runtime: {error}");
+    }
     Ok(())
 }
 
@@ -132,4 +126,50 @@ async fn complete_libraries_files(
         generate_libraries_downloads(minecraft_location, &resolved_version.libraries);
     download::download_concurrent(library_downloads, &progress, config).await?;
     Ok(())
+}
+
+async fn complete_java_runtime_files(
+    instance: &Instance,
+    progress: &DownloadState,
+    config: DownloadConfig,
+) -> Result<()> {
+    let lock_file = DATA_LOCATION
+        .get_instance_root(&instance.id)
+        .join(".java-runtime-ok");
+    if try_load_lock_file(&lock_file).is_some() {
+        info!("Found file \".java-runtime-ok\", no need to check Java runtime files.");
+        return Ok(());
+    }
+    info!("Checking and completing Mojang-provided Java runtime");
+    install::java::install_for_instance(instance, progress, config).await?;
+    info!("Saving Java runtime lock file");
+    let _ = save_lock_file(&lock_file);
+    Ok(())
+}
+
+/// Time-to-live applied by [`try_load_lock_file`] before a lock file is
+/// considered stale (10 days).
+pub const LOCK_FILE_TTL_SECONDS: u64 = 10 * 24 * 60 * 60;
+
+/// Reads a timestamped lock file written by [`save_lock_file`], returning `None`
+/// when it is missing, unreadable or older than [`LOCK_FILE_TTL_SECONDS`].
+pub fn try_load_lock_file(path: &Path) -> Option<()> {
+    let contents = std::fs::read_to_string(path).ok()?.parse::<u64>().ok()?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Incorrect system time")
+        .as_secs();
+    if now - contents > LOCK_FILE_TTL_SECONDS {
+        return None;
+    }
+    Some(())
+}
+
+/// Writes a lock file containing the current unix timestamp.
+pub fn save_lock_file(path: &Path) -> std::io::Result<()> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Incorrect system time")
+        .as_secs();
+    std::fs::write(path, now.to_string())
 }

--- a/crates/launch/src/lib.rs
+++ b/crates/launch/src/lib.rs
@@ -67,7 +67,6 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 #[serde(tag = "job", content = "progress")]
 pub enum LaunchEvent {
     Prepare,
-    RefreshAccount,
     InstallAuthlibInjector(DownloadState),
     CompleteFiles(DownloadState),
     GenerateScriptlet,
@@ -188,7 +187,14 @@ pub async fn launch(
             let mut status = status.lock().expect("Internal error");
             *status = LaunchEvent::CompleteFiles(progress.clone());
         }
-        complete_files(&instance, &minecraft_location, progress, &config.download).await?;
+        complete_files(
+            &instance,
+            &minecraft_location,
+            progress,
+            config.prefer_mojang_java,
+            &config.download,
+        )
+        .await?;
     }
 
     info!("Generating startup parameters");
@@ -380,7 +386,9 @@ async fn spawn_minecraft_process(
                 let mut status = status.lock().expect("Internal error");
                 *status = LaunchEvent::LogOpenALLoaded;
             }
-            if line.contains("Created") {
+            if (line.contains("Created") && line.contains("textures") && line.contains("-atlas"))
+                || line.contains("Found animation info")
+            {
                 let mut status = status.lock().expect("Internal error");
                 *status = LaunchEvent::LogTextureLoaded;
             }
@@ -403,9 +411,15 @@ async fn spawn_minecraft_process(
         }
     });
     let start = Instant::now();
-    while start.elapsed().as_secs() < 30
-        && *status_cloned.lock().expect("Internal error") != LaunchEvent::LogTextureLoaded
-    {
+    while start.elapsed().as_secs() < 20 {
+        if matches!(
+            &*status_cloned.lock().expect("Internal error"),
+            LaunchEvent::LogTextureLoaded
+                | LaunchEvent::LogLwjglVersion
+                | LaunchEvent::LogOpenALLoaded
+        ) {
+            break;
+        }
         async_io::Timer::after(Duration::from_secs(1)).await;
     }
     match PLATFORM_INFO.os_family {

--- a/crates/version/src/library.rs
+++ b/crates/version/src/library.rs
@@ -118,20 +118,12 @@ fn resolve_modloader_libraries(library: &Value) -> Result<ResolvedLibrary> {
     let base_url = library["url"]
         .as_str()
         .unwrap_or("https://libraries.minecraft.net/");
-    // Forge publishes its own artifact on its maven repository with the
-    // "-universal" classifier, but installs it locally under the plain file
-    // name. Keep the local path plain so it matches both the installed file
-    // and the classpath, and only classify the download URL. Skip libraries
-    // whose coordinate already carries a classifier to avoid doubling it.
-    let mut artifact = format!("{name}-{version}");
-    if package == "net/minecraftforge" && *name == "forge" && !artifact.ends_with("-universal") {
-        artifact.push_str("-universal");
-    }
-    let path = format!("{package}/{name}/{version}/{name}-{version}.jar");
+    let artifact = format!("{name}-{version}");
+    let path = format!("{package}/{name}/{version}/{artifact}.jar");
     Ok(ResolvedLibrary::Common(LibraryDownloadInfo {
         sha1: None,
         size: None,
-        url: format!("{base_url}{package}/{name}/{version}/{artifact}.jar"),
+        url: format!("{base_url}{path}"),
         path,
     }))
 }

--- a/src/views/LaunchView.vue
+++ b/src/views/LaunchView.vue
@@ -152,35 +152,61 @@ async function installGame() {
       }
       if (task.job === Job.InstallGame) {
         if (
-          task.downloadState?.phase === "VerifyExistingFiles" ||
-          (task.downloadState && task.downloadState.totalBytes === 0)
+          task.progress?.phase === "VerifyExistingFiles" ||
+          (task.progress && task.progress.totalBytes === 0)
         ) {
           progressDescription.value = "校验游戏文件";
           progressBarLoading.value = true;
-        } else if (task.downloadState?.phase === "DownloadFiles") {
-          progressDescription.value = `下载游戏文件 ${formatBytes(task.downloadState.completedBytes)} / ${formatBytes(task.downloadState.totalBytes)}`;
+        } else if (task.progress?.phase === "DownloadFiles") {
+          progressDescription.value = `下载游戏文件 ${formatBytes(task.progress.completedBytes)} / ${formatBytes(task.progress.totalBytes)}`;
           progressBarLoading.value = false;
-          progressBarValue.value = task.downloadState.completedBytes;
-          progressBarMax.value = task.downloadState.totalBytes;
+          progressBarValue.value = task.progress.completedBytes;
+          progressBarMax.value = task.progress.totalBytes;
         }
       }
       if (task.job === Job.InstallJava) {
         if (
-          task.downloadState?.phase === "VerifyExistingFiles" ||
-          (task.downloadState && task.downloadState.totalBytes === 0)
+          task.progress?.phase === "VerifyExistingFiles" ||
+          (task.progress && task.progress.totalBytes === 0)
         ) {
           progressDescription.value = "检查 Java 运行环境";
           progressBarLoading.value = true;
-        } else if (task.downloadState?.phase === "DownloadFiles") {
-          progressDescription.value = `下载 Java ${formatBytes(task.downloadState.completedBytes)}/${formatBytes(task.downloadState.totalBytes)}`;
+        } else if (task.progress?.phase === "DownloadFiles") {
+          progressDescription.value = `下载 Java ${formatBytes(task.progress.completedBytes)}/${formatBytes(task.progress.totalBytes)}`;
           progressBarLoading.value = false;
-          progressBarValue.value = task.downloadState.completedBytes;
-          progressBarMax.value = task.downloadState.totalBytes;
+          progressBarValue.value = task.progress.completedBytes;
+          progressBarMax.value = task.progress.totalBytes;
         }
       }
       if (task.job === Job.InstallModLoader) {
-        progressDescription.value = `安装 ${instanceStore.currentInstance.config.runtime.mod_loader_type}`;
-        progressBarLoading.value = true;
+        const modLoaderName = instanceStore.currentInstance.config.runtime.mod_loader_type;
+        const modLoaderProgress = task.progress;
+        if (!modLoaderProgress || modLoaderProgress.phase === "prepare") {
+          progressDescription.value = `安装 ${modLoaderName}`;
+          progressBarLoading.value = true;
+        } else if (
+          modLoaderProgress.phase === "downloadInstaller" ||
+          modLoaderProgress.phase === "prefetchDependencies"
+        ) {
+          const detail = modLoaderProgress.detail;
+          const stageText =
+            modLoaderProgress.phase === "downloadInstaller"
+              ? `下载 ${modLoaderName} 安装器`
+              : "下载依赖库";
+          if (!detail || detail.phase === "VerifyExistingFiles" || detail.totalBytes === 0) {
+            progressDescription.value = stageText;
+            progressBarLoading.value = true;
+          } else {
+            progressDescription.value = `${stageText} ${formatBytes(detail.completedBytes)} / ${formatBytes(detail.totalBytes)}`;
+            progressBarLoading.value = false;
+            progressBarValue.value = detail.completedBytes;
+            progressBarMax.value = detail.totalBytes;
+          }
+        } else if (modLoaderProgress.phase === "runInstaller") {
+          const message = modLoaderProgress.detail?.message ?? "";
+          progressDescription.value = `运行 ${modLoaderName} installer：${message}`;
+          progressBarLoading.value = true;
+        }
       }
     },
   });
@@ -196,9 +222,6 @@ async function launchGame() {
     onProgress: (task) => {
       if (task.job === "Prepare") {
         progressDescription.value = "准备启动";
-        progressBarLoading.value = true;
-      } else if (task.job === "RefreshAccount") {
-        progressDescription.value = "更新登录凭据";
         progressBarLoading.value = true;
       } else if (task.job === "CompleteFiles") {
         if (task.downloadState?.phase === "VerifyExistingFiles") {
@@ -320,6 +343,10 @@ function back() {
 
       p {
         font-size: 14px;
+        max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .progress {

--- a/src/views/settings/SettingsJVM.vue
+++ b/src/views/settings/SettingsJVM.vue
@@ -22,7 +22,7 @@
         <SettingItem
           v-if="runtimes.length === 0"
           :title="'未检测到已安装的 Java 运行环境'"
-          :description="'安装游戏时 Conic Launcher 会自动从 Mojang 服务器下载所需的 Java 运行环境'"></SettingItem>
+          :description="'开启「优先使用 Mojang 提供的 Java 运行环境」后，Conic Launcher 会自动从 Mojang 服务器下载所需的 Java 运行环境'"></SettingItem>
         <SettingItem
           v-for="runtime in runtimes"
           :key="runtime.path"


### PR DESCRIPTION
- Report Forge/NeoForge installer phases (prepare, installer download, dependency prefetch, subprocess output) to the frontend via a shared ModLoaderProgress payload; installer archives are now fetched through download_concurrent with maven .sha1 checksum verification
- Unify the install event wire format under the "progress" content key and render per-phase progress in LaunchView, with ellipsis overflow for long installer log lines
- Complete Mojang-provided Java runtime files during launch when preferred, guarded by a per-instance .java-runtime-ok lock file with a 10-day TTL; failures are non-fatal and fall back to system Java
- Skip Mojang Java installation unless prefer_mojang_java is enabled and no custom java_path is set
- Exit the post-launch wait loop within 20s once LWJGL/OpenAL/texture markers appear, and require the full "Created ... textures ... -atlas" line before marking texture loading complete
- Drop the unused RefreshAccount launch event
- Treat pre-existing files without expected checksums as already complete instead of re-downloading them on every run