### PR TITLE
fix(microsoft-auth): use v2.0 token endpoint and save refresh token early

### DIFF
--- a/crates/account/src/error.rs
+++ b/crates/account/src/error.rs
@@ -90,6 +90,9 @@ pub enum Error {
     #[error("Invalid device code, please try again")]
     BadVerificationCode,
 
+    #[error("HTTP request failed with status {status}: {body}")]
+    HttpResponse { status: u16, body: String },
+
     #[error(transparent)]
     Aborted(
         #[from]

--- a/crates/account/src/microsoft/device_code.rs
+++ b/crates/account/src/microsoft/device_code.rs
@@ -19,7 +19,7 @@ pub struct DeviceCodeResponse {
 }
 
 pub async fn request_device_code() -> Result<DeviceCodeResponse> {
-    Ok(HTTP_CLIENT
+    let response = HTTP_CLIENT
         .post("https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode")
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(
@@ -27,9 +27,16 @@ pub async fn request_device_code() -> Result<DeviceCodeResponse> {
                 .to_string(),
         )
         .send()
-        .await?
-        .json()
-        .await?)
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(Error::HttpResponse {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    serde_json::from_str(&body).map_err(Into::into)
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -41,7 +48,7 @@ pub struct DeviceCodePollResult {
 }
 
 pub async fn poll_device_code(device_code: &str) -> Result<DeviceCodePollResult> {
-    let response: Value = HTTP_CLIENT
+    let raw_response = HTTP_CLIENT
         .post("https://login.microsoftonline.com/consumers/oauth2/v2.0/token")
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(
@@ -51,9 +58,16 @@ pub async fn poll_device_code(device_code: &str) -> Result<DeviceCodePollResult>
                 + device_code,
         )
         .send()
-        .await?
-        .json()
         .await?;
+    let status = raw_response.status();
+    let body = raw_response.text().await?;
+    if !status.is_success() {
+        return Err(Error::HttpResponse {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    let response: Value = serde_json::from_str(&body)?;
     if let Some(error) = response["error"].as_str() {
         return Ok(DeviceCodePollResult {
             status: error.to_string(),

--- a/crates/account/src/microsoft/login_task.rs
+++ b/crates/account/src/microsoft/login_task.rs
@@ -60,7 +60,10 @@ pub(crate) async fn login_with_auth_code(
     reporter: &LoginReporter,
 ) -> Result<MicrosoftAccount> {
     reporter.report(LoginEvent::RedeemAccessToken);
-    let (access_token, refresh_token) = microsoft::redeem_access_token(code).await?;
+    let (access_token, refresh_token) = {
+        let tokens = microsoft::redeem_access_token(code).await?;
+        (tokens.access_token, tokens.refresh_token)
+    };
     finish_login(access_token, refresh_token, reporter).await
 }
 

--- a/crates/account/src/microsoft/microsoft_auth_step.rs
+++ b/crates/account/src/microsoft/microsoft_auth_step.rs
@@ -7,22 +7,38 @@ use shared::HTTP_CLIENT;
 
 use crate::error::*;
 
-pub async fn redeem_access_token(code: &str) -> Result<(String, String)> {
-    let response: Value = HTTP_CLIENT
-        .post("https://login.live.com/oauth20_token.srf")
+pub struct TokenPair {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+async fn check_response(response: reqwest::Response) -> Result<Value> {
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(Error::HttpResponse {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    serde_json::from_str(&body).map_err(Into::into)
+}
+
+pub async fn redeem_access_token(code: &str) -> Result<TokenPair> {
+    let response = HTTP_CLIENT
+        .post("https://login.microsoftonline.com/consumers/oauth2/v2.0/token")
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(
             "client_id=94a1414e-e9ad-4bda-94f0-3368d979b0cc".to_string()
                 + "&grant_type=authorization_code"
                 + "&code="
                 + code
-                + "&redirect_uri=https://login.live.com/oauth20_desktop.srf"
-                + "&scope=service::user.auth.xboxlive.com::MBI_SSL",
+                + "&redirect_uri=conic-launcher%3A%2F%2Foauth2%2Fmicrosoft%2Fcallback"
+                + "&scope=XboxLive.signin%20offline_access",
         )
         .send()
-        .await?
-        .json()
         .await?;
+    let response = check_response(response).await?;
     let access_token = response["access_token"]
         .as_str()
         .ok_or(Error::MicrosoftResponseMissingKey(
@@ -35,27 +51,27 @@ pub async fn redeem_access_token(code: &str) -> Result<(String, String)> {
             "refresh_token".to_string(),
         ))?
         .to_string();
-    Ok((access_token, refresh_token))
+    Ok(TokenPair {
+        access_token,
+        refresh_token,
+    })
 }
 
-pub(super) async fn get_access_token_from_refresh_token(
-    refresh_token: &str,
-) -> Result<(String, String)> {
-    let response: Value = HTTP_CLIENT
-        .post("https://login.live.com/oauth20_token.srf")
-        .header("Content-type", "application/x-www-form-urlencoded")
+pub(super) async fn get_access_token_from_refresh_token(refresh_token: &str) -> Result<TokenPair> {
+    let response = HTTP_CLIENT
+        .post("https://login.microsoftonline.com/consumers/oauth2/v2.0/token")
+        .header("Content-Type", "application/x-www-form-urlencoded")
         .body(
             "client_id=94a1414e-e9ad-4bda-94f0-3368d979b0cc".to_string()
                 + "&grant_type=refresh_token"
                 + "&refresh_token="
                 + refresh_token
-                + "&redirect_uri=https://login.live.com/oauth20_desktop.srf"
-                + "&scope=service::user.auth.xboxlive.com::MBI_SSL",
+                + "&redirect_uri=conic-launcher%3A%2F%2Foauth2%2Fmicrosoft%2Fcallback"
+                + "&scope=XboxLive.signin%20offline_access",
         )
         .send()
-        .await?
-        .json()
         .await?;
+    let response = check_response(response).await?;
     let access_token = response["access_token"]
         .as_str()
         .ok_or(Error::MicrosoftResponseMissingKey(
@@ -68,5 +84,8 @@ pub(super) async fn get_access_token_from_refresh_token(
             "refresh_token".to_string(),
         ))?
         .to_string();
-    Ok((access_token, refresh_token))
+    Ok(TokenPair {
+        access_token,
+        refresh_token,
+    })
 }

--- a/crates/account/src/microsoft/mod.rs
+++ b/crates/account/src/microsoft/mod.rs
@@ -110,8 +110,17 @@ pub async fn refresh_account(uuid: Uuid, force_refresh: bool) -> Result<Microsof
         }
     }
     info!("Start refreshing the account: {uuid}");
-    let (access_token, refresh_token) =
-        microsoft_auth_step::get_access_token_from_refresh_token(&account.refresh_token).await?;
+    let (access_token, refresh_token) = {
+        let tokens =
+            microsoft_auth_step::get_access_token_from_refresh_token(&account.refresh_token)
+                .await?;
+        (tokens.access_token, tokens.refresh_token)
+    };
+    // Save the new refresh_token immediately so a failure in the Xbox/XSTS/MC
+    // chain does not lose the rotated token.
+    let mut saved_account = account;
+    saved_account.refresh_token = refresh_token.clone();
+    update_account(uuid, &saved_account).await?;
     let refreshed_account = access_token_auth_flow(&access_token, &refresh_token).await?;
     update_account(uuid, &refreshed_account).await?;
     Ok(refreshed_account)

--- a/crates/account/src/microsoft_commands.rs
+++ b/crates/account/src/microsoft_commands.rs
@@ -98,10 +98,10 @@ pub struct GetAccessTokenResult {
 pub(crate) async fn cmd_microsoft_redeem_access_token(
     code: String,
 ) -> Result<GetAccessTokenResult> {
-    let (access_token, refresh_token) = crate::microsoft::redeem_access_token(&code).await?;
+    let tokens = crate::microsoft::redeem_access_token(&code).await?;
     Ok(GetAccessTokenResult {
-        access_token,
-        refresh_token,
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
     })
 }
 


### PR DESCRIPTION
- Switch token redemption and refresh from login.live.com to login.microsoftonline.com/consumers/oauth2/v2.0/token
- Change scope to XboxLive.signin offline_access so refresh_token is always returned
- Align redirect_uri with the deep-link scheme used by the frontend
- Persist the new refresh_token before running the Xbox/XSTS/MC chain to prevent token loss on intermediate failures
- Add HTTP status code checks on all Microsoft OAuth endpoints
- Remove leftover dbg!() call that leaked token data to stderr