### PR TITLE
feat(settings): link Mojang brand guidelines in About disclaimer

### DIFF
--- a/src/locales/de_de.ts
+++ b/src/locales/de_de.ts
@@ -570,7 +570,7 @@ export default {
             creditsBMCLAPI:
                 "Die Standard-Mirror-Konfiguration von Conic Launcher enthält BMCLAPI von bangbang93 als Beschleunigungsquelle für den Download einiger Minecraft-Ressourcen",
             disclaimer:
-                "Conic Launcher ist kein offizielles Minecraft-Produkt und ist nicht von Mojang Studios genehmigt oder mit diesem verbunden. „Minecraft“ ist eine Marke von Mojang AB. Jede Verwendung der Marke Minecraft in diesem Projekt entspricht den Marken- und Asset-Richtlinien von Mojang Studios.",
+                "Conic Launcher ist kein offizielles Minecraft-Produkt und ist nicht von Mojang Studios genehmigt oder mit diesem verbunden. „Minecraft“ ist eine Marke von Mojang AB. Jede Verwendung der Marke Minecraft in diesem Projekt entspricht den <a href='https://www.minecraft.net/en-us/usage-guidelines'>Marken- und Asset-Richtlinien</a> von Mojang Studios.",
         },
     },
 }

--- a/src/locales/en_us.ts
+++ b/src/locales/en_us.ts
@@ -563,7 +563,7 @@ export default {
             creditsBMCLAPI:
                 "The default mirror configuration of Conic Launcher includes BMCLAPI provided by bangbang93 as a download acceleration source for some Minecraft resources",
             disclaimer:
-                'Conic Launcher is not an official Minecraft product and is not approved or associated with Mojang Studios. "Minecraft" is a trademark of Mojang AB. Any use of the Minecraft brand in this project complies with the Mojang Studios Brand and Asset Guidelines.',
+                'Conic Launcher is not an official Minecraft product and is not approved or associated with Mojang Studios. "Minecraft" is a trademark of Mojang AB. Any use of the Minecraft brand in this project complies with the Mojang Studios <a href="https://www.minecraft.net/en-us/usage-guidelines">Brand and Asset Guidelines</a>.',
         },
     },
 }

--- a/src/locales/es_es.ts
+++ b/src/locales/es_es.ts
@@ -572,7 +572,7 @@ export default {
             creditsBMCLAPI:
                 "La configuración de servidores espejo predeterminada de Conic Launcher incluye BMCLAPI, proporcionado por bangbang93, como fuente de aceleración de descargas para algunos recursos de Minecraft",
             disclaimer:
-                "Conic Launcher no es un producto oficial de Minecraft y no está aprobado ni asociado a Mojang Studios. «Minecraft» es una marca comercial de Mojang AB. Cualquier uso de la marca Minecraft en este proyecto cumple con las directrices de marca y recursos de Mojang Studios.",
+                "Conic Launcher no es un producto oficial de Minecraft y no está aprobado ni asociado a Mojang Studios. «Minecraft» es una marca comercial de Mojang AB. Cualquier uso de la marca Minecraft en este proyecto cumple con las <a href='https://www.minecraft.net/en-us/usage-guidelines'>directrices de marca y recursos</a> de Mojang Studios.",
         },
     },
 }

--- a/src/locales/fr_fr.ts
+++ b/src/locales/fr_fr.ts
@@ -569,7 +569,7 @@ export default {
             creditsBMCLAPI:
                 "La configuration miroir par défaut de Conic Launcher inclut BMCLAPI, fourni par bangbang93, comme source d'accélération de téléchargement pour certaines ressources de Minecraft",
             disclaimer:
-                "Conic Launcher n'est pas un produit officiel Minecraft et n'est ni approuvé ni associé à Mojang Studios. « Minecraft » est une marque déposée de Mojang AB. Toute utilisation de la marque Minecraft dans ce projet est conforme aux consignes de marque et de ressources de Mojang Studios.",
+                "Conic Launcher n'est pas un produit officiel Minecraft et n'est ni approuvé ni associé à Mojang Studios. « Minecraft » est une marque déposée de Mojang AB. Toute utilisation de la marque Minecraft dans ce projet est conforme aux <a href='https://www.minecraft.net/en-us/usage-guidelines'>consignes de marque et de ressources</a> de Mojang Studios.",
         },
     },
 }

--- a/src/locales/ja_jp.ts
+++ b/src/locales/ja_jp.ts
@@ -562,7 +562,7 @@ export default {
             creditsBMCLAPI:
                 "Conic Launcher のデフォルトのミラー設定には、一部のMinecraftリソースのダウンロードを高速化するソースとして bangbang93 氏提供の BMCLAPI が含まれています",
             disclaimer:
-                "Conic Launcher は非公式のMinecraft製品であり、Mojang Studios の承認を受けたものでも提携関係にあるものでもありません。「Minecraft」は Mojang AB の商標です。本プロジェクトにおけるMinecraftブランドのあらゆる使用は、Mojang Studios のブランドおよびアセットガイドラインに準拠しています。",
+                "Conic Launcher は非公式のMinecraft製品であり、Mojang Studios の承認を受けたものでも提携関係にあるものでもありません。「Minecraft」は Mojang AB の商標です。本プロジェクトにおけるMinecraftブランドのあらゆる使用は、Mojang Studios の<a href='https://www.minecraft.net/en-us/usage-guidelines'>ブランドおよびアセットガイドライン</a>に準拠しています。",
         },
     },
 }

--- a/src/locales/ko_kr.ts
+++ b/src/locales/ko_kr.ts
@@ -555,7 +555,7 @@ export default {
             creditsBMCLAPI:
                 "Conic Launcher의 기본 미러 구성에는 bangbang93이 제공하는 BMCLAPI가 일부 Minecraft 리소스의 다운로드 가속 소스로 포함되어 있습니다",
             disclaimer:
-                'Conic Launcher는 공식 Minecraft 제품이 아니며, Mojang Studios의 승인을 받았거나 제휴 관계에 있지 않습니다. "Minecraft"는 Mojang AB의 상표입니다. 이 프로젝트에서 Minecraft 브랜드의 모든 사용은 Mojang Studios 브랜드 및 에셋 가이드라인을 준수합니다.',
+                'Conic Launcher는 공식 Minecraft 제품이 아니며, Mojang Studios의 승인을 받았거나 제휴 관계에 있지 않습니다. "Minecraft"는 Mojang AB의 상표입니다. 이 프로젝트에서 Minecraft 브랜드의 모든 사용은 Mojang Studios <a href="https://www.minecraft.net/en-us/usage-guidelines">브랜드 및 에셋 가이드라인</a>을 준수합니다.',
         },
     },
 }

--- a/src/locales/pl_pl.ts
+++ b/src/locales/pl_pl.ts
@@ -566,7 +566,7 @@ export default {
             creditsBMCLAPI:
                 "Domyślna konfiguracja serwerów lustrzanych Conic Launcher obejmuje BMCLAPI dostarczane przez bangbang93 jako źródło przyspieszające pobieranie niektórych zasobów Minecraft",
             disclaimer:
-                "Conic Launcher nie jest oficjalnym produktem Minecraft i nie jest zatwierdzony ani powiązany z Mojang Studios. „Minecraft” jest znakiem towarowym Mojang AB. Każde użycie marki Minecraft w tym projekcie jest zgodne z wytycznymi dotyczącymi marki i zasobów Mojang Studios.",
+                "Conic Launcher nie jest oficjalnym produktem Minecraft i nie jest zatwierdzony ani powiązany z Mojang Studios. „Minecraft” jest znakiem towarowym Mojang AB. Każde użycie marki Minecraft w tym projekcie jest zgodne z <a href='https://www.minecraft.net/en-us/usage-guidelines'>wytycznymi dotyczącymi marki i zasobów</a> Mojang Studios.",
         },
     },
 }

--- a/src/locales/pt_br.ts
+++ b/src/locales/pt_br.ts
@@ -567,7 +567,7 @@ export default {
             creditsBMCLAPI:
                 "A configuração de espelhos padrão do Conic Launcher inclui o BMCLAPI, fornecido por bangbang93, como fonte de aceleração de download para alguns recursos do Minecraft",
             disclaimer:
-                'O Conic Launcher não é um produto oficial do Minecraft e não é aprovado nem associado à Mojang Studios. "Minecraft" é uma marca registrada da Mojang AB. Qualquer uso da marca Minecraft neste projeto está em conformidade com as Diretrizes de Marca e Ativos da Mojang Studios.',
+                'O Conic Launcher não é um produto oficial do Minecraft e não é aprovado nem associado à Mojang Studios. "Minecraft" é uma marca registrada da Mojang AB. Qualquer uso da marca Minecraft neste projeto está em conformidade com as <a href="https://www.minecraft.net/en-us/usage-guidelines">Diretrizes de Marca e Ativos</a> da Mojang Studios.',
         },
     },
 }

--- a/src/locales/ru_ru.ts
+++ b/src/locales/ru_ru.ts
@@ -565,7 +565,7 @@ export default {
             creditsBMCLAPI:
                 "Зеркала по умолчанию в Conic Launcher включают BMCLAPI от bangbang93 как источник ускорения загрузки некоторых ресурсов Minecraft",
             disclaimer:
-                "Conic Launcher не является официальным продуктом Minecraft, не одобрен им и не связан с Mojang Studios. «Minecraft» является товарным знаком Mojang AB. Любое использование бренда Minecraft в этом проекте соответствует правилам использования бренда и материалов Mojang Studios.",
+                "Conic Launcher не является официальным продуктом Minecraft, не одобрен им и не связан с Mojang Studios. «Minecraft» является товарным знаком Mojang AB. Любое использование бренда Minecraft в этом проекте соответствует <a href='https://www.minecraft.net/en-us/usage-guidelines'>правилам использования бренда и материалов</a> Mojang Studios.",
         },
     },
 }

--- a/src/locales/tr_tr.ts
+++ b/src/locales/tr_tr.ts
@@ -564,7 +564,7 @@ export default {
             creditsBMCLAPI:
                 "Conic Launcher'ın varsayılan ayna yapılandırması, bazı Minecraft kaynakları için indirme hızlandırma kaynağı olarak bangbang93 tarafından sağlanan BMCLAPI'yi içerir",
             disclaimer:
-                "Conic Launcher resmi bir Minecraft ürünü değildir ve Mojang Studios tarafından onaylanmamıştır ya da Mojang Studios ile bağı yoktur. \"Minecraft\", Mojang AB'nin ticari markasıdır. Bu projede Minecraft markasının her türlü kullanımı Mojang Studios Marka ve Varlık Yönergeleri'ne uygundur.",
+                "Conic Launcher resmi bir Minecraft ürünü değildir ve Mojang Studios tarafından onaylanmamıştır ya da Mojang Studios ile bağı yoktur. \"Minecraft\", Mojang AB'nin ticari markasıdır. Bu projede Minecraft markasının her türlü kullanımı Mojang Studios <a href='https://www.minecraft.net/en-us/usage-guidelines'>Marka ve Varlık Yönergeleri</a>'ne uygundur.",
         },
     },
 }

--- a/src/locales/zh_cn.ts
+++ b/src/locales/zh_cn.ts
@@ -549,7 +549,7 @@ export default {
             creditsBMCLAPI:
                 "Conic Launcher 镜像列表的默认配置包含 bangbang93 提供的 BMCLAPI 作为部分 Minecraft 资源的下载加速源",
             disclaimer:
-                'Conic Launcher 不是官方的 Minecraft 产品，也未获得 Mojang Studios 的批准或关联。"Minecraft"是 Mojang AB 的商标，本项目对 Minecraft 品牌的任何使用均符合 Mojang Studios 的品牌与资产指南。',
+                'Conic Launcher 不是官方的 Minecraft 产品，也未获得 Mojang Studios 的批准或关联。"Minecraft"是 Mojang AB 的商标，本项目对 Minecraft 品牌的任何使用均符合 Mojang Studios 的<a href="https://www.minecraft.net/en-us/usage-guidelines">品牌与资产指南</a>。',
         },
     },
 }

--- a/src/locales/zh_tw.ts
+++ b/src/locales/zh_tw.ts
@@ -546,7 +546,7 @@ export default {
             creditsBMCLAPI:
                 "Conic Launcher 鏡像站列表的預設設定包含 bangbang93 提供的 BMCLAPI 作為部分 Minecraft 資源的下載加速來源",
             disclaimer:
-                "Conic Launcher 不是官方的 Minecraft 產品，也未獲得 Mojang Studios 的批准或關聯。「Minecraft」是 Mojang AB 的商標，本專案對 Minecraft 品牌的任何使用均符合 Mojang Studios 的品牌與資產指南。",
+                "Conic Launcher 不是官方的 Minecraft 產品，也未獲得 Mojang Studios 的批准或關聯。「Minecraft」是 Mojang AB 的商標，本專案對 Minecraft 品牌的任何使用均符合 Mojang Studios 的<a href='https://www.minecraft.net/en-us/usage-guidelines'>品牌與資產指南</a>。",
         },
     },
 }

--- a/src/views/settings/SettingsAbout.vue
+++ b/src/views/settings/SettingsAbout.vue
@@ -88,9 +88,7 @@
         {{ appVersion ?? "0.0.0" }}
       </p>
       <p class="copyright">Copyright 2022-2026 ConicMC developers. All rights reserved.</p>
-      <p class="text">
-        {{ t("settings.about.disclaimer") }}
-      </p>
+      <p class="text" v-html="t('settings.about.disclaimer')" @click="onDisclaimerClick"></p>
     </div>
   </div>
 </template>
@@ -107,6 +105,15 @@ import { onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
+
+function onDisclaimerClick(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+  if (target.tagName === "A") {
+    event.preventDefault();
+    const href = (target as HTMLAnchorElement).href;
+    if (href) openUrl(href);
+  }
+}
 
 async function openLogFolder() {
   const dataLocation = await getDataLocation();
@@ -152,6 +159,13 @@ onMounted(async () => {
     text-align: center;
     line-height: 1.5;
     width: calc(100% - 96px);
+    a {
+      color: var(--ctp-blue);
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
Render the 品牌与资产指南 / Brand and Asset Guidelines phrase in the About disclaimer as a clickable link to Mojang's usage guidelines.

- Wraps the guidelines phrase in an `<a href>...` across all 12 locale files
- Renders the disclaimer with `v-html`
- Clicking the link prevents default navigation and opens the URL in the system browser via `@tauri-apps/plugin-opener`'s `openUrl`